### PR TITLE
Use CRAN packages, when possible; update to R-3.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-# Use the r-base docker to start from
-FROM rocker/rstudio:3.5.0
+# Use the r-base docker to start
+FROM rocker/rstudio:3.5.1
 
 RUN apt-get -y update \
-  && apt-get install -y python \
-  && apt-get install -y python-sympy python-pip python-setuptools python3-pip python-dev python3-dev \
-  && apt-get install -y libcurl4-openssl-dev libssl-dev  zlib1g-dev libudunits2-dev libxml2-dev \
-  && Rscript -e "install.packages(c('devtools','xpose','tidyr','shiny','shinydashboard','shinyBS','shinyAce'), repos = 'http://cran.us.r-project.org')" \
-  && Rscript -e "install.packages(c('gridExtra','collapsibleTree','DT','R3port','RCurl'), repos = 'http://cran.us.r-project.org')" \
-  && Rscript -e "devtools::install_github('ronkeizer/vpc')" \
-  && Rscript -e "devtools::install_github('nlmixrdevelopment/n1qn1')" \
-  && Rscript -e "devtools::install_github('nlmixrdevelopment/SnakeCharmR')" \
-  && Rscript -e "install.packages(c('RxODE','nlmixr'), repos = 'http://cran.us.r-project.org')" \
+  && apt-get install -y \
+              python \
+              python-sympy python-pip python-setuptools python3-pip python-dev python3-dev \
+              libcurl4-openssl-dev libssl-dev  zlib1g-dev libudunits2-dev libxml2-dev \
+  && Rscript -e "install.packages(c('devtools','xpose','tidyr','shiny','shinydashboard','shinyBS','shinyAce','gridExtra','collapsibleTree','DT','R3port','RCurl','vpc','n1qn1','SnakeCharmR'), repos = 'http://cran.us.r-project.org')" \
+  && Rscript -e "install.packages(c('RxODE','nlmixr'), INSTALL_opts = c("--install-tests"), repos = 'http://cran.us.r-project.org')" \
   && Rscript -e "devtools::install_github('nlmixrdevelopment/xpose.nlmixr')" \
   && Rscript -e "devtools::install_github('richardhooijmaijers/shinyMixR')"
 


### PR DESCRIPTION
Fix #1

This also reduces the number of command lines used (more packages are installed per function call) and installs the RxODE and nlmixr tests.