### PR TITLE
Modularize

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Auto detect text files and perform LF normalization
-* text=auto

--- a/prod.nlmixr2/001-install-pak.sh
+++ b/prod.nlmixr2/001-install-pak.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+Rscript -e "install.packages('pak')"

--- a/prod.nlmixr2/010-packages-standard.sh
+++ b/prod.nlmixr2/010-packages-standard.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+Rscript -e "pak::pak(c('tidyverse', 'xpose', 'RCurl', 'vpc', 'flextable', 'rmarkdown', 'patchwork'))"

--- a/prod.nlmixr2/020-pharmacometrics-general.sh
+++ b/prod.nlmixr2/020-pharmacometrics-general.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-Rscript -e "pak::pak(c('vpc', 'PKNCA'))"
+Rscript -e "pak::pak(c('tidyvpc', 'PKNCA', 'vpc'))"

--- a/prod.nlmixr2/020-pharmacometrics-general.sh
+++ b/prod.nlmixr2/020-pharmacometrics-general.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+Rscript -e "pak::pak(c('vpc', 'PKNCA'))"

--- a/prod.nlmixr2/030-nlmixr2.sh
+++ b/prod.nlmixr2/030-nlmixr2.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+Rscript -e "pak::pak('nlmixr2')"

--- a/prod.nlmixr2/035-nlmixr2-others.sh
+++ b/prod.nlmixr2/035-nlmixr2-others.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-Rscript -e "pak::pak('xpose.nlmixr2', 'ggPMX', 'babelmixr2', 'nonmem2rx', 'nlmixr2lib')"
+Rscript -e "pak::pak(c('xpose.nlmixr2', 'ggPMX', 'babelmixr2', 'nonmem2rx', 'nlmixr2lib'))"

--- a/prod.nlmixr2/035-nlmixr2-others.sh
+++ b/prod.nlmixr2/035-nlmixr2-others.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+Rscript -e "pak::pak('xpose.nlmixr2', 'ggPMX', 'babelmixr2', 'nonmem2rx', 'nlmixr2lib')"

--- a/prod.nlmixr2/040-shinyMixR.sh
+++ b/prod.nlmixr2/040-shinyMixR.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+Rscript -e "pak::pak('richardhooijmaijers/shinyMixR')"

--- a/prod.nlmixr2/999-pak-cleanup.sh
+++ b/prod.nlmixr2/999-pak-cleanup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Remove cache files
+Rscript -e "pak::pak_cleanup(force = TRUE)"

--- a/prod.nlmixr2/Dockerfile
+++ b/prod.nlmixr2/Dockerfile
@@ -19,10 +19,8 @@ RUN apt-get clean all && \
       libssl-dev \
       libudunits2-dev \
       libxml2-dev \
-      libxml2-dev \
       libxt-dev \
       xclip \
-      zlib1g-dev \
       zlib1g-dev \
    && \
    apt-get clean all && \

--- a/prod.nlmixr2/Dockerfile
+++ b/prod.nlmixr2/Dockerfile
@@ -31,7 +31,9 @@ RUN mkdir -p /srv/r-installation
 COPY *.R *.sh /srv/r-installation
 
 # Run all files ending with "sh"; then cleanup any apt installation remnants
-RUN run-parts --exit-on-error --verbose --regex '.*sh' /srv/r-installation && \
+RUN cd /srv/r-installation && \
+    chmod 755 *sh && \
+    run-parts --exit-on-error --verbose --regex '.*sh' /srv/r-installation && \
     apt-get clean all && \
     apt-get purge && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/prod.nlmixr2/Dockerfile
+++ b/prod.nlmixr2/Dockerfile
@@ -1,32 +1,33 @@
 FROM rocker/verse:latest
 
 RUN apt-get clean all && \
-	apt-get update && \
-	apt-get upgrade -y && \
-	apt-get install -y \
-		libhdf5-dev \
-		libxml2-dev \
-		libpng-dev \
-		libxt-dev \
-		zlib1g-dev \
-		libbz2-dev \
-		liblzma-dev \
-		libglpk40 \
-		libgit2-dev \
-    xclip \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    zlib1g-dev \
-    libudunits2-dev \
-    libxml2-dev \
-    libcairo2-dev \
-    cmake \
-    libgmp-dev \
-    libmpfr-dev \
-    libmpc-dev \
-	&& apt-get clean all && \
-	apt-get purge && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+      libhdf5-dev \
+      libxml2-dev \
+      libpng-dev \
+      libxt-dev \
+      zlib1g-dev \
+      libbz2-dev \
+      liblzma-dev \
+      libglpk40 \
+      libgit2-dev \
+      xclip \
+      libcurl4-openssl-dev \
+      libssl-dev \
+      zlib1g-dev \
+      libudunits2-dev \
+      libxml2-dev \
+      libcairo2-dev \
+      cmake \
+      libgmp-dev \
+      libmpfr-dev \
+      libmpc-dev \
+   && \
+   apt-get clean all && \
+   apt-get purge && \
+   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN Rscript -e "install.packages(c('tidyverse','devtools','xpose','tidyr','shiny','shinydashboard','shinyBS','shinyAce','gridExtra','collapsibleTree','DT','R3port','RCurl','vpc','n1qn1','reticulate','flextable','rmarkdown','patchwork'));"
 RUN Rscript -e "install.packages(c('rxode2','nlmixr2','xpose.nlmixr2','ggPMX'), INSTALL_opts = '--install-tests' )"

--- a/prod.nlmixr2/Dockerfile
+++ b/prod.nlmixr2/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get clean all && \
    apt-get purge && \
    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN mkdir -p /srv/r-installation
 COPY *.R *.sh /srv/r-installation
 
 # Run all files ending with "sh"; then cleanup any apt installation remnants

--- a/prod.nlmixr2/Dockerfile
+++ b/prod.nlmixr2/Dockerfile
@@ -27,8 +27,8 @@ RUN apt-get clean all && \
    apt-get purge && \
    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN Rscript -e "install.packages(c('tidyverse','devtools','xpose','shiny','shinydashboard','shinyBS','shinyAce','gridExtra','collapsibleTree','DT','R3port','RCurl','vpc','n1qn1','reticulate','flextable','rmarkdown','patchwork'));"
-RUN Rscript -e "install.packages(c('rxode2','nlmixr2','xpose.nlmixr2','ggPMX'), INSTALL_opts = '--install-tests' )"
+RUN Rscript -e "install.packages(c('tidyverse','xpose','RCurl','vpc','flextable','rmarkdown','patchwork'))"
+RUN Rscript -e "install.packages(c('rxode2','nlmixr2','xpose.nlmixr2','ggPMX'), INSTALL_opts = '--install-tests')"
 RUN Rscript -e "devtools::install_github('richardhooijmaijers/shinyMixR')"
 
 COPY examples /home/rstudio/examples

--- a/prod.nlmixr2/Dockerfile
+++ b/prod.nlmixr2/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get clean all && \
    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN Rscript -e "install.packages(c('tidyverse','xpose','RCurl','vpc','flextable','rmarkdown','patchwork'))"
-RUN Rscript -e "install.packages(c('rxode2','nlmixr2','xpose.nlmixr2','ggPMX'), INSTALL_opts = '--install-tests')"
+RUN Rscript -e "install.packages(c('nlmixr2','xpose.nlmixr2','ggPMX'), INSTALL_opts = '--install-tests')"
 RUN Rscript -e "devtools::install_github('richardhooijmaijers/shinyMixR')"
 
 COPY examples /home/rstudio/examples

--- a/prod.nlmixr2/Dockerfile
+++ b/prod.nlmixr2/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get clean all && \
    apt-get purge && \
    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN Rscript -e "install.packages(c('tidyverse','devtools','xpose','tidyr','shiny','shinydashboard','shinyBS','shinyAce','gridExtra','collapsibleTree','DT','R3port','RCurl','vpc','n1qn1','reticulate','flextable','rmarkdown','patchwork'));"
+RUN Rscript -e "install.packages(c('tidyverse','devtools','xpose','shiny','shinydashboard','shinyBS','shinyAce','gridExtra','collapsibleTree','DT','R3port','RCurl','vpc','n1qn1','reticulate','flextable','rmarkdown','patchwork'));"
 RUN Rscript -e "install.packages(c('rxode2','nlmixr2','xpose.nlmixr2','ggPMX'), INSTALL_opts = '--install-tests' )"
 RUN Rscript -e "devtools::install_github('richardhooijmaijers/shinyMixR')"
 

--- a/prod.nlmixr2/Dockerfile
+++ b/prod.nlmixr2/Dockerfile
@@ -27,8 +27,12 @@ RUN apt-get clean all && \
    apt-get purge && \
    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN Rscript -e "install.packages(c('tidyverse','xpose','RCurl','vpc','flextable','rmarkdown','patchwork'))"
-RUN Rscript -e "install.packages(c('nlmixr2','xpose.nlmixr2','ggPMX'), INSTALL_opts = '--install-tests')"
-RUN Rscript -e "devtools::install_github('richardhooijmaijers/shinyMixR')"
+COPY *.R *.sh /srv/r-installation
+
+# Run all files ending with "sh"; then cleanup any apt installation remnants
+RUN run-parts --exit-on-error --verbose --regex '.*sh' /srv/r-installation && \
+    apt-get clean all && \
+    apt-get purge && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY examples /home/rstudio/examples

--- a/prod.nlmixr2/Dockerfile
+++ b/prod.nlmixr2/Dockerfile
@@ -4,26 +4,26 @@ RUN apt-get clean all && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
-      libhdf5-dev \
-      libxml2-dev \
-      libpng-dev \
-      libxt-dev \
-      zlib1g-dev \
+      cmake \
       libbz2-dev \
-      liblzma-dev \
-      libglpk40 \
-      libgit2-dev \
-      xclip \
+      libcairo2-dev \
       libcurl4-openssl-dev \
+      libgit2-dev \
+      libglpk40 \
+      libgmp-dev \
+      libhdf5-dev \
+      liblzma-dev \
+      libmpc-dev \
+      libmpfr-dev \
+      libpng-dev \
       libssl-dev \
-      zlib1g-dev \
       libudunits2-dev \
       libxml2-dev \
-      libcairo2-dev \
-      cmake \
-      libgmp-dev \
-      libmpfr-dev \
-      libmpc-dev \
+      libxml2-dev \
+      libxt-dev \
+      xclip \
+      zlib1g-dev \
+      zlib1g-dev \
    && \
    apt-get clean all && \
    apt-get purge && \


### PR DESCRIPTION
This modularizes package installation so that different companies (mainly me) can install additional packages simply without disrupting the other work here.  It could also allow the apt part to be put into the individual scripts so apt and package installation are more closely linked.

This builds on top of #11, but it effectively replaces that PR.